### PR TITLE
CSS が読み込まれない問題の修正 & LexV2 の npm run build がこけていた問題の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+!tailwind.config.js
+!common.d.ts

--- a/web-kendra/tailwind.config.js
+++ b/web-kendra/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/web-lexv2/src/types/common.d.ts
+++ b/web-lexv2/src/types/common.d.ts
@@ -1,0 +1,1 @@
+declare module 'stream-browserify'

--- a/web-lexv2/tailwind.config.js
+++ b/web-lexv2/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
CDK の default の .gitignore が悪さをしていました。修正しました。