### PR TITLE
CustomDataSource を Sync したときに権限エラーになる問題を修正

### DIFF
--- a/cdk/lib/simple-kendra-stack.ts
+++ b/cdk/lib/simple-kendra-stack.ts
@@ -248,7 +248,8 @@ export class SimpleKendraStack extends cdk.Stack {
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         resources: [
-          cdk.Token.asString(customDataSource.resource.getAtt('Arn')),
+          // cdk.Token.asString(customDataSource.resource.getAtt('Arn')) だと Index ID が undefined になる
+          `${cdk.Token.asString(index.getAtt('Arn'))}/data-source/${cdk.Token.asString(customDataSource.resource.getAtt('Id'))}`,
         ],
         actions: [
           'kendra:StartDataSourceSyncJob',


### PR DESCRIPTION
CustomResource (DataSource) に対して getAttr('Arn') すると Index ID が undefined になる問題を修正

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
