### PR TITLE
fix:S3のオブジェクト所有者の変更

### DIFF
--- a/cdk/lib/simple-kendra-stack.ts
+++ b/cdk/lib/simple-kendra-stack.ts
@@ -64,6 +64,7 @@ export class SimpleKendraStack extends cdk.Stack {
       encryption: s3.BucketEncryption.S3_MANAGED,
       autoDeleteObjects: true,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
+      objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
       serverAccessLogsPrefix: 'logs',
       enforceSSL: true,
     });
@@ -176,6 +177,7 @@ export class SimpleKendraStack extends cdk.Stack {
       encryption: s3.BucketEncryption.S3_MANAGED,
       autoDeleteObjects: true,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
+      objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
       serverAccessLogsPrefix: 'logs',
       enforceSSL: true,
     });
@@ -392,11 +394,13 @@ export class SimpleKendraStack extends cdk.Stack {
           removalPolicy: cdk.RemovalPolicy.DESTROY,
         },
         loggingBucketProps: {
+          objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
           autoDeleteObjects: true,
           removalPolicy: cdk.RemovalPolicy.DESTROY,
           serverAccessLogsPrefix: 'logs',
         },
         cloudFrontLoggingBucketProps: {
+          objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
           autoDeleteObjects: true,
           removalPolicy: cdk.RemovalPolicy.DESTROY,
           serverAccessLogsPrefix: 'logs',

--- a/cdk/lib/simple-lexv2-stack.ts
+++ b/cdk/lib/simple-lexv2-stack.ts
@@ -295,11 +295,13 @@ export class SimpleLexV2Stack extends cdk.Stack {
         loggingBucketProps: {
           autoDeleteObjects: true,
           removalPolicy: cdk.RemovalPolicy.DESTROY,
+          objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
           serverAccessLogsPrefix: 'logs',
         },
         cloudFrontLoggingBucketProps: {
           autoDeleteObjects: true,
           removalPolicy: cdk.RemovalPolicy.DESTROY,
+          objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
           serverAccessLogsPrefix: 'logs',
         },
         cloudFrontDistributionProps: {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
ServerAccessLogが設定されているS3バケットについて、オブジェクトの所有者を[Object Writer]に修正。 　
オブジェクトの所有者が[Bucket Owner Enforced]（デフォルト設定）だと、ServerAccessLog設定時のACLsの内容と競合してしまいエラーになる。  
