### PR TITLE
deploy-time-buildを最新版にアップグレード(CodeBuildを使ってデプロイ)

### DIFF
--- a/cdk/lib/simple-kendra-stack.ts
+++ b/cdk/lib/simple-kendra-stack.ts
@@ -493,6 +493,10 @@ export class SimpleKendraStack extends cdk.Stack {
         id: 'AwsSolutions-CFR4',
         reason: 'Allow to use default certificate',
       },
+      {
+        id: 'AwsSolutions-CB4',
+        reason: 'KMS is not used, because Codebuild is encrypted by default',
+      },
     ]);
   }
 }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -25,7 +25,7 @@
     "aws-cdk-lib": "2.77.0",
     "cdk-nag": "^2.25.8",
     "constructs": "^10.0.0",
-    "deploy-time-build": "^0.2.2",
+    "deploy-time-build": "^0.3.1",
     "source-map-support": "^0.5.21"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "aws-cdk-lib": "2.77.0",
         "cdk-nag": "^2.25.8",
         "constructs": "^10.0.0",
-        "deploy-time-build": "^0.2.2",
+        "deploy-time-build": "^0.3.1",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -9057,9 +9057,9 @@
       }
     },
     "node_modules/deploy-time-build": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/deploy-time-build/-/deploy-time-build-0.2.3.tgz",
-      "integrity": "sha512-B5BtftLaRleFL1+JBubh14VAXJ/CAMHXrC4LTIeh4zZISKgpLQaEeMfOkRozJcC6znqwxrKc6PB5zTJQ4GBdHw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/deploy-time-build/-/deploy-time-build-0.3.1.tgz",
+      "integrity": "sha512-cqS9S8Y2ssiycs6JobxneKXGOjaN2A3UAWAFwgSZVJtSZOnNLAE6MmnpUiGBDjXq9wsuPcmcAIHINI6TJVWjDA==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.38.0",
         "constructs": "^10.0.5"


### PR DESCRIPTION
*Issue #, if available:*
Fixes aws-samples/simple-lex-kendra-jp#42

*Description of changes:*
フロントエンドのデプロイに利用している`deploy-time-build`を`0.3.1`にアップグレード。 　
`0.2.x`はLambdaを利用してビルドを行っていたが、npm もしくは、Lambdaのアップデートによってエラーが発生する様になった（詳細な原因は不明）。
`0.3.x`ではCodeBuildを利用してビルドを行うため、上記のエラーを回避することが可能になる。

