### PR TITLE
Update region settings

### DIFF
--- a/cdk/bin/simple-lex-kendra-jp.ts
+++ b/cdk/bin/simple-lex-kendra-jp.ts
@@ -52,7 +52,7 @@ Aspects.of(app).add(new AwsSolutionsChecks());
     webAclCloudFront: webAclStack.webAcl,
     crossRegionReferences: true,
     env: {
-      region: 'ap-northeast-1',
+      region: 'us-east-1',
     },
   });
 
@@ -65,7 +65,7 @@ Aspects.of(app).add(new AwsSolutionsChecks());
     webAclCloudFront: webAclStack.webAcl,
     crossRegionReferences: true,
     env: {
-      region: 'ap-northeast-1',
+      region: 'us-east-1',
     },
   });
 

--- a/docs/03_DEPLOY_KENDRA.md
+++ b/docs/03_DEPLOY_KENDRA.md
@@ -160,7 +160,7 @@ export REACT_APP_PREDICT_STREAM_FUNCTION_ARN=<Predict Stream Function ARN>
 - 上記 `<...>` の値は `cdk deploy SimpleKendraStack` の出力を確認して適切な値に書き換えてください。
   - `<Kendra API Endpoint>` は `SimpleKendraStack.KendraApiEndpointxxxx = ...` の形式で出力された Endpoint に `kendra` の path を追加したものを設定。最終的に https://xxxxxxxxxx.execute-api.region.amazonaws.com/prod/kendra のような値になる。
   - `<Identity Pool ID>` は `SimpleKendraStack.IdentityPoolId = ...` の値
-  - `<Region>` は CDK でデプロイしたリージョン (例: ap-northeast-1)
+  - `<Region>` は CDK でデプロイしたリージョン (例: us-east-1)
   - `<Cognito User Pool ID>` は `SimpleKendraStack.CognitoUserPoolId = ...` の値
   - `<Cognito User Pool Client ID>` は `SimpleKendraStack.CognitoUserPoolClientId = ...` の値
   -   - `<Predict Stream Function ARN>` は `SimpleKendraStack.PredictStreamFunctionArn = ...` の値 (Streaming Response を行う Lambda 関数の ARN)

--- a/docs/04_DEPLOY_LEXV2.md
+++ b/docs/04_DEPLOY_LEXV2.md
@@ -55,7 +55,7 @@ export REACT_APP_REGION=<Region>
   - `<Identity Pool ID>` は `SimpleLexV2Stack.IdentityPoolId = ...` の値
   - `<Bot ID>` は `SimpleLexV2Stack.BotId = ...` の値
   - `<Bot Alias ID>` は `SimpleLexV2Stack.BotAliasId = ...` の値
-  - `<Region>` は CDK でデプロイしたリージョン (例: ap-northeast-1)
+  - `<Region>` は CDK でデプロイしたリージョン (例: us-east-1)
 - `cdk deploy SimpleLexV2Stack` の出力が確認できない場合は、再度デプロイコマンドを実行して出力を確認するか、[CloudFormation](https://console.aws.amazon.com/cloudformation) の SimpleLexV2Stack から Outputs タブで確認してください。
 
 続いて、3000 番ポートで待ち受けを開始します。


### PR DESCRIPTION
*Description of changes:*

Claude V2 does not support the Tokyo region, and various AWS resources are separated in two regions (us-east-1 and ap-northeast-1), which users find confusing, so I am changing it so that all resources exist in us-east-1.
